### PR TITLE
Generate CSR, Private keys using cryptography library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dynamic = ["version"]
 dependencies = [
     # "frappe~=15.0.0" # Installed and managed by bench.
     "qrcode~=7.4.2",
+    "asn1~=2.7.0",
 ]
 
 [build-system]

--- a/zatca_integration/clearence_util.py
+++ b/zatca_integration/clearence_util.py
@@ -13,9 +13,9 @@ import qrcode
 from zatca_integration.common_util import decode_invoice, get_seller_information, get_buyer_information
 from zatca_integration.saudi_arabia_electronic_invoicing.utils import get_zatca_config, get_previous_invoice_counter, get_previous_invoice_hash
 from zatca_integration.saudi_arabia_electronic_invoicing.signing_engine.final_invoice_signing import process_invoice_for_zatca_submission, xml_base64_decode
+import io
 
 def generate_einvoice(doc, method=None):
-    
     
     # Buyer Information
     customer = frappe.get_doc("Customer", doc.customer)
@@ -453,7 +453,6 @@ def extract_qr_code_from_cleared_invoice(cleared_invoice_xml):
     img = qr.make_image(fill_color="black", back_color="white")
 
     # Save the QR code image to a byte stream
-    import io
     img_byte_arr = io.BytesIO()
     img.save(img_byte_arr, format='PNG')
     img_byte_arr = img_byte_arr.getvalue()

--- a/zatca_integration/common_util.py
+++ b/zatca_integration/common_util.py
@@ -221,6 +221,38 @@ def generate_invoice_payload_from_xml(xml_content: bytes) -> dict:
         "invoice": xml_base64_encoded,
     }
 
+#Not tested
+def extract_canonical_xml(xml_file):
+    """
+    Remove ZATCA signature-related nodes and return the cleaned XML string.
+    Used to generate a hash for the current invoice.
+    """
+    try:
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+
+        namespaces = {
+            'ext': 'urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2',
+            'cac': 'urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2',
+            'cbc': 'urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2'
+        }
+
+        for ext_elem in root.findall('.//ext:UBLExtensions', namespaces):
+            root.remove(ext_elem)
+
+        for sig_elem in root.findall('.//cac:Signature', namespaces):
+            root.remove(sig_elem)
+
+        # Remove <cac:AdditionalDocumentReference> with cbc:ID == "QR"
+        for doc_ref in root.findall('.//cac:AdditionalDocumentReference', namespaces):
+            id_node = doc_ref.find('.//cbc:ID', namespaces)
+            if id_node is not None and id_node.text == "QR":
+                root.remove(doc_ref)
+
+        return ET.tostring(root, encoding='unicode')
+    except Exception as e:
+        print(f"Error canonicalizing XML: {e}")
+        return None
 
 def generate_invoice_hash(xml_file=None):
     """

--- a/zatca_integration/common_util.py
+++ b/zatca_integration/common_util.py
@@ -221,38 +221,6 @@ def generate_invoice_payload_from_xml(xml_content: bytes) -> dict:
         "invoice": xml_base64_encoded,
     }
 
-#Not tested
-def extract_canonical_xml(xml_file):
-    """
-    Remove ZATCA signature-related nodes and return the cleaned XML string.
-    Used to generate a hash for the current invoice.
-    """
-    try:
-        tree = ET.parse(xml_file)
-        root = tree.getroot()
-
-        namespaces = {
-            'ext': 'urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2',
-            'cac': 'urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2',
-            'cbc': 'urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2'
-        }
-
-        for ext_elem in root.findall('.//ext:UBLExtensions', namespaces):
-            root.remove(ext_elem)
-
-        for sig_elem in root.findall('.//cac:Signature', namespaces):
-            root.remove(sig_elem)
-
-        # Remove <cac:AdditionalDocumentReference> with cbc:ID == "QR"
-        for doc_ref in root.findall('.//cac:AdditionalDocumentReference', namespaces):
-            id_node = doc_ref.find('.//cbc:ID', namespaces)
-            if id_node is not None and id_node.text == "QR":
-                root.remove(doc_ref)
-
-        return ET.tostring(root, encoding='unicode')
-    except Exception as e:
-        print(f"Error canonicalizing XML: {e}")
-        return None
 
 def generate_invoice_hash(xml_file=None):
     """

--- a/zatca_integration/saudi_arabia_electronic_invoicing/utils.py
+++ b/zatca_integration/saudi_arabia_electronic_invoicing/utils.py
@@ -1,10 +1,6 @@
 import frappe
 import base64
 from frappe import _
-import hashlib
-from datetime import datetime
-from xml import etree 
-import lxml.etree as MyTree
 from cryptography import x509
 from cryptography.hazmat._oid import NameOID
 from cryptography.hazmat.backends import default_backend
@@ -504,21 +500,17 @@ def get_zatca_config(company):
     }
     
 def get_previous_invoice_counter(production_csid):
-    # Get the latest Zatca Transaction for the given production_csid based on transaction_time
     latest_transaction = frappe.get_all('Zatca Transactions', 
                                         filters={'production_csid': production_csid}, 
                                         fields=['invoice_icv'], 
                                         order_by='transaction_time desc', 
                                         limit_page_length=1)
     if latest_transaction:
-        # Return the invoice_icv of the latest transaction
         return latest_transaction[0].invoice_icv
     else:
-        # Return 0 if there are no Zatca Transactions
         return 0
     
 def get_previous_invoice_hash(production_csid):
-    # Get the latest Zatca Transaction for the given production_csid based on transaction_time
     latest_transaction = frappe.get_all('Zatca Transactions', 
                                         filters={'production_csid': production_csid}, 
                                         fields=['invoice_hash','name'], 
@@ -526,7 +518,6 @@ def get_previous_invoice_hash(production_csid):
                                         limit_page_length=1)
     if latest_transaction:
         # Return the invoice_hash of the latest transaction
-        # frappe.throw(str(latest_transaction[0].name))
         return latest_transaction[0].invoice_hash
     else:
         # Return default hash if there are no Zatca Transactions


### PR DESCRIPTION
This Pull Request introduces a **new approach to generating the CSR, CSID, and private keys** required by ZATCA, in compliance with their e-invoicing Phase 2 specifications.

#### Key Changes

-   Replaces dependency on the **official ZATCA SDK** with a fully native Python implementation using the **`cryptography`** library.
    
-   Introduces functions to:
    
    -   Generate **EC (Elliptic Curve) private keys** using the `SECP256K1` curve.
        
    -   Construct **CSRs (Certificate Signing Requests)** with the correct subject fields and extensions as per ZATCA requirements.
        
    -   Compute and store **CSID (Certificate Signing Identifier)** from the generated CSR and public key.
        
-   Stores generated keys and CSRs securely in Frappe DocTypes for traceability and future reference.
    

####  Why This Approach?

-   **Portability & Maintainability**: Using the `cryptography` library removes the need for maintaining and debugging opaque SDK dependencies.
    
-   **Security**: Direct control over key generation and CSR content allows us to comply precisely with ZATCA's requirements (e.g., specific key formats, hashing, and encoding).
    
-   **Flexibility**: Easier to audit, customize, and extend in the future (e.g., support additional certificate extensions or rotate keys).
    
-   **Error Handling**: Adds improved logging and exception handling using Frappe’s standard tools, making troubleshooting easier.
    

####  Testing

-   CSR and key generation tested against ZATCA's compliance tools.
    
-   All outputs validated for format, encoding, and field structure.
    
-   Includes support for regenerating and saving keys from within the Zatca CSR Settings DocType.