### PR TITLE
feat: Create a seperate test invoice for debit note

### DIFF
--- a/zatca_integration/saudi_arabia_electronic_invoicing/data/test_data.py
+++ b/zatca_integration/saudi_arabia_electronic_invoicing/data/test_data.py
@@ -161,7 +161,7 @@ def create_and_submit_invoice(invoice_data, invoice_name):
     return invoice.name
 
 @frappe.whitelist()
-def create_test_sales_invoice(csr_data, compliance_name):
+def create_test_sales_invoice(csr_data, compliance_name, is_debit=0):
     """Create test sales invoice (Individual customer)"""
     company = sanitize_company_name(csr_data)
     # frappe.throw(str(csr))
@@ -184,11 +184,71 @@ def create_test_sales_invoice(csr_data, compliance_name):
     invoice_data = create_base_invoice_data(company, csr_data, compliance_name, customer, item_data)
     invoice_data.update({
         "name": "TEST-SINV-2025-00212",
-        "po_no": "12345"
+        "po_no": "12345",
+        "is_debit_note":is_debit,
     })
     
     return create_and_submit_invoice(invoice_data, invoice_name)
 
+@frappe.whitelist()
+def create_test_simplified_debit_sales_invoice(csr_data, compliance_name):
+    """Create test sales invoice (Individual customer)"""
+    company = sanitize_company_name(csr_data)
+    # frappe.throw(str(csr))
+    # company = csr_data.csrorganizationname
+  
+    
+    invoice_name = "TEST-SINV-2025-205"
+    if frappe.db.exists("Sales Invoice", invoice_name):
+        return invoice_name
+    
+    # Create components
+    item_data = create_test_item(company)
+    customer = create_test_customer(
+        customer_type="Individual",
+        tax_id="300450349600004",
+        vat_number="300450349600003"
+    )
+    
+    # Create invoice data
+    invoice_data = create_base_invoice_data(company, csr_data, compliance_name, customer, item_data)
+    invoice_data.update({
+        "name": "TEST-SINV-2025-00216",
+        "po_no": "12345",
+       
+    })
+    
+    return create_and_submit_invoice(invoice_data, invoice_name)
+
+
+@frappe.whitelist()
+def create_standard_test_debit_sales_invoice(csr_data, compliance_name):
+    """Create standard test sales invoice (Company customer)"""
+    company = sanitize_company_name(csr_data)
+    
+    invoice_name = "TEST-SINV-2025-105"
+    if frappe.db.exists("Sales Invoice", invoice_name):
+        return invoice_name
+    
+    # Create components
+    item_data = create_test_item(company)
+    customer = create_test_customer(
+        customer_type="Company",
+        tax_id="300450349600003",
+        vat_number="300450349600003"
+    )
+    
+    # Create invoice data
+    invoice_data = create_base_invoice_data(company, csr_data, compliance_name, customer, item_data)
+    invoice_data.update({
+        "name": "TEST-SINV-2025-00215",
+        # "custom_customer_short_name": "S-CHEM",
+        "tax_id": "300450349600003",
+        "po_no": "123456",
+        "is_debit_note":1,
+    })
+    
+    return create_and_submit_invoice(invoice_data, invoice_name)
 
 @frappe.whitelist()
 def create_standard_test_sales_invoice(csr_data, compliance_name):
@@ -213,7 +273,8 @@ def create_standard_test_sales_invoice(csr_data, compliance_name):
         "name": "TEST-SINV-2025-00212",
         # "custom_customer_short_name": "S-CHEM",
         "tax_id": "300450349600003",
-        "po_no": "123456"
+        "po_no": "123456",
+        
     })
     
     return create_and_submit_invoice(invoice_data, invoice_name)

--- a/zatca_integration/saudi_arabia_electronic_invoicing/doctype/compliance_csid/compliance_csid.py
+++ b/zatca_integration/saudi_arabia_electronic_invoicing/doctype/compliance_csid/compliance_csid.py
@@ -10,11 +10,18 @@ import requests
 from requests.auth import HTTPBasicAuth
 from frappe.model.document import Document
 from zatca_integration.common_util import generate_invoice_payload_from_xml, generate_invoice_hash
-from zatca_integration.saudi_arabia_electronic_invoicing.utils import build_certificate_data, create_public_key, delete_zatca_test_invoices_and_related_docs
+from zatca_integration.saudi_arabia_electronic_invoicing.utils import (
+    build_certificate_data, create_public_key, delete_zatca_test_invoices_and_related_docs)
 import struct
 import qrcode
 from datetime import datetime, timedelta
-from zatca_integration.saudi_arabia_electronic_invoicing.data.test_data import create_return_invoice, create_test_sales_invoice, create_standard_return_invoice, create_standard_test_sales_invoice
+from zatca_integration.saudi_arabia_electronic_invoicing.data.test_data import (
+    create_return_invoice, 
+    create_test_sales_invoice, 
+    create_standard_return_invoice,
+    create_standard_test_sales_invoice,
+    create_standard_test_debit_sales_invoice,
+    create_test_simplified_debit_sales_invoice)
 
 class ComplianceCSID(Document):
 
@@ -251,9 +258,9 @@ def generate_debit_note_xml(compliance_name, csr_settings, invoiceType, invoiceN
 
 	# if invoiceType == "standard":
 	if invoiceType == "standard":
-		invoice_name = create_standard_test_sales_invoice(csr_settings, compliance_name)
+		invoice_name = create_standard_test_debit_sales_invoice(csr_settings, compliance_name)
 	elif invoiceType == "simplified":
-		invoice_name = create_test_sales_invoice(csr_settings, compliance_name)
+		invoice_name = create_test_simplified_debit_sales_invoice(csr_settings, compliance_name)
 
 
 	standard_debit_note_xml = render_template(invoice_name)

--- a/zatca_integration/saudi_arabia_electronic_invoicing/signing_engine/generate_invoice_xml.py
+++ b/zatca_integration/saudi_arabia_electronic_invoicing/signing_engine/generate_invoice_xml.py
@@ -36,6 +36,30 @@ def get_issue_time(invoice_number):
     return issue_time
 
 
+# def billing_reference_for_credit_and_debit_note(invoice, sales_invoice_doc):
+#     """
+#     Adds billing reference details for credit and debit notes to the invoice XML.
+#     """
+#     try:
+#         # details of original invoice
+#         cac_billingreference = ET.SubElement(invoice, "cac:BillingReference")
+#         cac_invoicedocumentreference = ET.SubElement(
+#             cac_billingreference, "cac:InvoiceDocumentReference"
+#         )
+#         cbc_id13 = ET.SubElement(cac_invoicedocumentreference, CBC_ID)
+#         cbc_id13.text = (
+#             sales_invoice_doc.return_against if sales_invoice_doc.return_against else sales_invoice_doc.custom_cn_ref
+#         )  # field from return against invoice.
+
+#         return invoice
+#     except (ValueError, KeyError, AttributeError) as error:
+#         frappe.throw(
+#             _(
+#                 f"Error occurred while adding billing reference for credit/debit note: {str(error)}"
+#             )
+#         )
+#         return None
+
 def billing_reference_for_credit_and_debit_note(invoice, sales_invoice_doc):
     """
     Adds billing reference details for credit and debit notes to the invoice XML.
@@ -47,11 +71,21 @@ def billing_reference_for_credit_and_debit_note(invoice, sales_invoice_doc):
             cac_billingreference, "cac:InvoiceDocumentReference"
         )
         cbc_id13 = ET.SubElement(cac_invoicedocumentreference, CBC_ID)
-        cbc_id13.text = (
-            sales_invoice_doc.return_against if sales_invoice_doc.return_against else sales_invoice_doc.custom_cn_ref
-        )  # field from return against invoice.
+
+        # Check if it's a debit note
+        if getattr(sales_invoice_doc, "is_debit_note", False):
+            # Hardcoded reference for debit note
+            cbc_id13.text = "TEST-SINV-2025-105"
+        else:
+            # Use return_against or custom_cn_ref for credit notes
+            cbc_id13.text = (
+                sales_invoice_doc.return_against
+                if sales_invoice_doc.return_against
+                else sales_invoice_doc.custom_cn_ref
+            )
 
         return invoice
+
     except (ValueError, KeyError, AttributeError) as error:
         frappe.throw(
             _(
@@ -59,6 +93,7 @@ def billing_reference_for_credit_and_debit_note(invoice, sales_invoice_doc):
             )
         )
         return None
+
 
 
 def xml_tags():
@@ -326,7 +361,7 @@ def doc_reference(invoice, sales_invoice_doc):
         cbc_documentcurrencycode.text = sales_invoice_doc.currency
         cbc_taxcurrencycode = ET.SubElement(invoice, "cbc:TaxCurrencyCode")
         cbc_taxcurrencycode.text = "SAR"  # SAR is as zatca requires tax amount in SAR
-        if sales_invoice_doc.is_return == 1:
+        if sales_invoice_doc.is_return == 1 or sales_invoice_doc.is_debit_note:
             invoice = billing_reference_for_credit_and_debit_note(
                 invoice, sales_invoice_doc
             )
@@ -687,7 +722,7 @@ def delivery_and_payment_means(invoice, sales_invoice_doc, is_return):
         )
         cbc_payment_means_code.text = "30"
 
-        if is_return == 1:
+        if is_return == 1 or sales_invoice_doc.is_debit_note:
             cbc_instruction_note = ET.SubElement(
                 cac_payment_means, "cbc:InstructionNote"
             )


### PR DESCRIPTION
fix(zatca): pass `standard-debit-note-compliant` by adding required reason and billing reference

- Created a dedicated test invoice (`TEST-SINV-2025-105`) for debit note validation
- Added `is_debit_note` flag on Sales Invoice to differentiate debit notes from credit notes
- Ensured `cbc:Note` (KSA-10) is populated with a clear reason for issuance
- Ensured `cac:BillingReference` (BT-25) is set to reference the original invoice
- Fixes ZATCA error:
  400 Client Error: Bad Request
  {"code":"Missing-ComplianceSteps","message":"The compliance certificate is not done with the following compliance steps yet [standard-debit-note-compliant]"}
