### PR TITLE
fix: Enhance cron jobs and have an outside report button on sales invoice

### DIFF
--- a/zatca_integration/clearence_util.py
+++ b/zatca_integration/clearence_util.py
@@ -7,6 +7,7 @@ import uuid
 from datetime import date, datetime, timedelta
 
 import frappe
+from frappe import _
 import qrcode
 import requests
 from frappe.utils import get_datetime
@@ -32,7 +33,7 @@ from zatca_integration.saudi_arabia_electronic_invoicing.utils import (
 )
 
 
-def generate_einvoice(doc, submit_now=True):
+def generate_einvoice(doc, submit_now=True, skip_success_message=False):
     company = frappe.get_doc("Company", doc.company)
 
     compliance_csid_doc = None
@@ -98,7 +99,8 @@ def generate_einvoice(doc, submit_now=True):
     validate_invoice_dates(doc, company, customer_type)
     if doc.custom_is_zatca_test:
         return
-    frappe.msgprint("Sales Invoice sent to ZATCA", alert=True)
+    if not skip_success_message and not frappe.flags.get("zatca_bulk_report"):
+        frappe.msgprint("Sales Invoice sent to ZATCA", alert=True)
     try:
         if customer_type == "Company":
             zatca_status_field = "clearanceStatus"
@@ -478,6 +480,8 @@ def display_error_ui(validation_results, doc):
         return frappe.throw(html_output, title="ZATCA Submission Failed")
     elif warning_messages:
         doc.custom_has_warnings = 1
+        if frappe.flags.get("zatca_bulk_report"):
+            return
         return frappe.msgprint(title="ZATCA Warning", msg=html_output, indicator="orange")
 
 
@@ -617,6 +621,100 @@ def resend_einvoice(doc):
     if isinstance(doc, dict):
         doc = frappe.get_doc(doc)
     generate_einvoice(doc)
+
+
+@frappe.whitelist()
+def bulk_resend_einvoices(invoice_names):
+    """Submit multiple Sales Invoices to ZATCA (same flow as ZATCA Actions → Report on the form)."""
+
+    if isinstance(invoice_names, str):
+        invoice_names = json.loads(invoice_names)
+
+    if not invoice_names:
+        frappe.throw(_("Select at least one Sales Invoice"))
+
+    seen = set()
+    unique_names = []
+    for n in invoice_names:
+        if n and n not in seen:
+            seen.add(n)
+            unique_names.append(n)
+
+    success = []
+    failed = []
+    skipped = []
+
+    frappe.flags.zatca_bulk_report = True
+    try:
+        for name in unique_names:
+            try:
+                doc = frappe.get_doc("Sales Invoice", name)
+            except frappe.DoesNotExistError:
+                failed.append({"name": name, "message": _("Not found")})
+                continue
+
+            if not frappe.has_permission("Sales Invoice", "read", doc):
+                failed.append({"name": name, "message": _("No permission")})
+                continue
+
+            if doc.docstatus != 1:
+                skipped.append({"name": name, "message": _("Not submitted")})
+                continue
+
+            status = doc.get("custom_zatca_submit_status")
+            if status in ("REPORTED", "CLEARED"):
+                skipped.append({"name": name, "message": _("Already {0}").format(status)})
+                continue
+
+            company = frappe.get_doc("Company", doc.company)
+            if not doc.custom_is_zatca_test:
+                if not company.get("custom_enable_zatca_e_invoicing"):
+                    skipped.append(
+                        {"name": name, "message": _("ZATCA e-invoicing is not enabled for this company")}
+                    )
+                    continue
+                if company.get("country") != "Saudi Arabia":
+                    skipped.append(
+                        {"name": name, "message": _("Company country is not Saudi Arabia")}
+                    )
+                    continue
+                if company.get("custom_zatca_phase") != "ZATCA Phase 2":
+                    skipped.append(
+                        {"name": name, "message": _("Company is not on ZATCA Phase 2")}
+                    )
+                    continue
+
+            try:
+                generate_einvoice(doc, skip_success_message=True)
+                doc.reload()
+                if doc.custom_zatca_submit_status in ("REPORTED", "CLEARED"):
+                    success.append(name)
+                elif doc.custom_is_zatca_test:
+                    skipped.append(
+                        {
+                            "name": name,
+                            "message": _("ZATCA test invoice (not submitted to production)"),
+                        }
+                    )
+                else:
+                    skipped.append(
+                        {
+                            "name": name,
+                            "message": _(
+                                "Submission did not reach REPORTED/CLEARED; check the invoice and ZATCA settings"
+                            ),
+                        }
+                    )
+            except Exception as e:
+                frappe.log_error(
+                    message=frappe.get_traceback(),
+                    title=f"ZATCA bulk report failed: {name}",
+                )
+                failed.append({"name": name, "message": str(e)})
+    finally:
+        frappe.flags.zatca_bulk_report = False
+
+    return {"success": success, "failed": failed, "skipped": skipped}
 
 
 def _handle_submitted_doc_response(

--- a/zatca_integration/public/js/sales_invoice_list.js
+++ b/zatca_integration/public/js/sales_invoice_list.js
@@ -1,4 +1,78 @@
 frappe.listview_settings['Sales Invoice'] = {
+    onload: function (listview) {
+        listview.page.add_inner_button(__('ZATCA Report'), function () {
+            const names = listview.get_checked_items(true) || [];
+            if (!names.length) {
+                frappe.msgprint(__('Select at least one Sales Invoice by ticking the checkboxes.'));
+                return;
+            }
+            frappe.confirm(
+                __('Report {0} selected invoice(s) to ZATCA? This runs the same action as ZATCA Actions → Report on each invoice.', [
+                    names.length,
+                ]),
+                () => {
+                    frappe.dom.freeze(__('Reporting to ZATCA...'));
+                    frappe.call({
+                        method: 'zatca_integration.clearence_util.bulk_resend_einvoices',
+                        args: { invoice_names: names },
+                        callback: function (r) {
+                            frappe.dom.unfreeze();
+                            const result = r.message || {};
+                            const parts = [];
+                            if (result.success && result.success.length) {
+                                parts.push(
+                                    '<p><strong>' +
+                                        __('Succeeded') +
+                                        ` (${result.success.length})</strong><br>` +
+                                        frappe.utils.escape_html(result.success.join(', ')) +
+                                        '</p>'
+                                );
+                            }
+                            if (result.skipped && result.skipped.length) {
+                                const skipLines = result.skipped
+                                    .map(
+                                        (row) =>
+                                            frappe.utils.escape_html(row.name) +
+                                            ': ' +
+                                            frappe.utils.escape_html(row.message || '')
+                                    )
+                                    .join('<br>');
+                                parts.push(
+                                    '<p><strong>' +
+                                        __('Skipped') +
+                                        ` (${result.skipped.length})</strong><br>${skipLines}</p>`
+                                );
+                            }
+                            if (result.failed && result.failed.length) {
+                                const failLines = result.failed
+                                    .map(
+                                        (row) =>
+                                            frappe.utils.escape_html(row.name) +
+                                            ': ' +
+                                            frappe.utils.escape_html(row.message || '')
+                                    )
+                                    .join('<br>');
+                                parts.push(
+                                    '<p><strong>' +
+                                        __('Failed') +
+                                        ` (${result.failed.length})</strong><br>${failLines}</p>`
+                                );
+                            }
+                            frappe.msgprint({
+                                title: __('ZATCA bulk report'),
+                                message: parts.join('<hr>') || __('Finished'),
+                                wide: true,
+                            });
+                            listview.refresh();
+                        },
+                        error: function () {
+                            frappe.dom.unfreeze();
+                        },
+                    });
+                }
+            );
+        });
+    },
     get_indicator: function (doc) {
 		const status_colors = {
 			Draft: "grey",

--- a/zatca_integration/saudi_arabia_electronic_invoicing/background_task.py
+++ b/zatca_integration/saudi_arabia_electronic_invoicing/background_task.py
@@ -29,7 +29,27 @@ def is_zatca_compliance_ready(company_name):
     return compliance_doc, None
 
 
+B2C_COMPLIANCE_BATCH_JOB_ID = "zatca_integration:b2c_compliance_batch_submit"
+B2C_COMPLIANCE_BATCH_TIMEOUT = 30 * 60  # 30 minutes (RQ worker must allow this timeout on `long` queue)
+
+
 def send_multiple_signed_compliance_invoices_to_zatca():
+    """
+    Scheduled Job Type entry point: enqueue the batch job on the background worker.
+
+    The worker runs ``_run_send_multiple_signed_compliance_invoices_to_zatca``, processes
+    all matching invoices until none remain or the 30-minute timeout is reached, then exits.
+    """
+    frappe.enqueue(
+        "zatca_integration.saudi_arabia_electronic_invoicing.background_task._run_send_multiple_signed_compliance_invoices_to_zatca",
+        queue="long",
+        timeout=B2C_COMPLIANCE_BATCH_TIMEOUT,
+        deduplicate=True,
+        job_id=B2C_COMPLIANCE_BATCH_JOB_ID,
+    )
+
+
+def _run_send_multiple_signed_compliance_invoices_to_zatca():
     """
     Automatically send all signed B2C invoices (not yet reported) to ZATCA compliance API.
     """


### PR DESCRIPTION
-   `send_multiple_signed_compliance_invoices_to_zatca`  (still the method registered on  Scheduled Job Type) now only  `frappe.enqueue`s  the real work.
-   `_run_send_multiple_signed_compliance_invoices_to_zatca`  holds the previous logic (loop companies → invoices →  `bg_generate_einvoice`), runs in a worker, and  ends naturally  when there is nothing left to process (same as before, just not on the scheduler process).

### Worker settings

-   `queue="long"`  – use the long worker so jobs are not stuck on the default queue.
-   `timeout=1800`  (30 minutes) – passed explicitly so the job can run up to 30 minutes even though Frappe’s default  long  queue timeout is 25 minutes (1500 s).
-   `deduplicate=True`  with  `job_id="zatca_integration:b2c_compliance_batch_submit"`  – if the scheduler fires again while a batch is  queued or running, Frappe will  not  enqueue a second copy (avoids overlapping batches).

-   `onload`: inner button  “ZATCA Report”  on the list page (same bar as other list actions).
-   Uses  row checkboxes  →  `get_checked_items(true)`  for names.
-   Asks for confirmation, freezes the screen with “Reporting to ZATCA…”, calls the bulk method, then shows a  wide summary  (Succeeded / Skipped / Failed) and  refreshes  the list.
