### PR TITLE
fix: Update the retentions

### DIFF
--- a/zatca_integration/clearence_util.py
+++ b/zatca_integration/clearence_util.py
@@ -19,6 +19,7 @@ from zatca_integration.common_util import (
     generate_invoice_hash,
     get_buyer_information,
     get_seller_information,
+    get_zatca_invoice_transaction_code,
 )
 from zatca_integration.saudi_arabia_electronic_invoicing.signing_engine.final_invoice_signing import (  # noqa: E501
     process_invoice_for_zatca_submission,
@@ -320,13 +321,7 @@ def _prepare_invoice_data(doc, config):
     """Prepare invoice data for submission"""
     customer = frappe.get_doc("Customer", doc.customer)
     customer_type = customer.customer_type
-
-    if customer_type == "Company":
-        invoice_type = "0100000"
-    elif customer_type == "Individual":
-        invoice_type = "0200000"
-    else:
-        frappe.throw("Customer Type is not Supported")
+    invoice_type = get_zatca_invoice_transaction_code(doc)
 
     # Get seller and buyer information
     seller = get_seller_information(config["compliance_csr"])

--- a/zatca_integration/clearence_util.py
+++ b/zatca_integration/clearence_util.py
@@ -19,7 +19,6 @@ from zatca_integration.common_util import (
     generate_invoice_hash,
     get_buyer_information,
     get_seller_information,
-    get_zatca_invoice_transaction_code,
 )
 from zatca_integration.saudi_arabia_electronic_invoicing.signing_engine.final_invoice_signing import (  # noqa: E501
     process_invoice_for_zatca_submission,
@@ -321,7 +320,13 @@ def _prepare_invoice_data(doc, config):
     """Prepare invoice data for submission"""
     customer = frappe.get_doc("Customer", doc.customer)
     customer_type = customer.customer_type
-    invoice_type = get_zatca_invoice_transaction_code(doc)
+
+    if customer_type == "Company":
+        invoice_type = "0100000"
+    elif customer_type == "Individual":
+        invoice_type = "0200000"
+    else:
+        frappe.throw("Customer Type is not Supported")
 
     # Get seller and buyer information
     seller = get_seller_information(config["compliance_csr"])

--- a/zatca_integration/common_util.py
+++ b/zatca_integration/common_util.py
@@ -25,6 +25,36 @@ def decode_invoice(encoded_invoice):
     return decoded_string
 
 
+def is_foreign_customer(customer):
+    """Buyer outside KSA. ZATCA does not require buyer VAT or additional ID on export invoices."""
+    country = (
+        customer.get("custom_country")
+        if isinstance(customer, dict)
+        else getattr(customer, "custom_country", None)
+    )
+    return bool(country) and country != "Saudi Arabia"
+
+
+def validate_company_buyer_identification(customer):
+    """
+    ZATCA E-Invoicing Resolution Annex 5.3–5.4:
+    - Export (non-KSA buyer): buyer VAT and additional buyer ID are not mandatory.
+    - Saudi B2B: buyer VAT if applicable, or registration scheme + number if not VAT-registered.
+    """
+    if customer.customer_type != "Company" or is_foreign_customer(customer):
+        return
+
+    has_vat = bool(customer.custom_vat_number or customer.get("tax_id"))
+    has_registration = bool(
+        customer.custom_registration_scheme and customer.custom_registration_number
+    )
+    if not (has_vat or has_registration):
+        frappe.throw(
+            "Saudi company customers must have a VAT Number or both "
+            "Registration Scheme and Registration Number."
+        )
+
+
 def get_buyer_information(customer_name):
     customer = frappe.get_doc("Customer", customer_name)
     country_code = get_country_code(customer.custom_country)
@@ -34,17 +64,7 @@ def get_buyer_information(customer_name):
         if not address:
             frappe.throw("Customer must have a primary address")
 
-        # Either VAT or Registration Scheme and Registration Number are required
-        if not customer.custom_vat_number and not customer.custom_registration_scheme:
-            frappe.throw(
-                "Either VAT Number or Registration Scheme and Registration Number "
-                "are required for Company"
-            )
-        if not customer.custom_vat_number and not customer.custom_registration_number:
-            frappe.throw(
-                "Either VAT Number or Registration Scheme and Registration Number "
-                "are required for Company "
-            )
+        validate_company_buyer_identification(customer)
 
         # ZATCA Address Validation
         # Address Line 1 is required
@@ -55,7 +75,7 @@ def get_buyer_information(customer_name):
         # Building Number must be 4 digits if country_code is SA
         if not address.address_line2:
             frappe.throw("Building Number is required for Company type customer")
-        if country_code == "sa" and len(address.address_line2) != 4:
+        if country_code == "SA" and len(address.address_line2) != 4:
             frappe.throw(
                 "Building Number must be 4 digits for Company type customer in Saudi Arabia"
             )
@@ -83,8 +103,12 @@ def get_buyer_information(customer_name):
         return {
             "organizationName": customer.customer_name,
             "vatNumber": customer.custom_vat_number,
-            "registrationScheme": get_registration_scheme_code(customer.custom_registration_scheme),
-            "registrationNumber": customer.custom_registration_number,
+            "registrationScheme": (
+                get_registration_scheme_code(customer.custom_registration_scheme)
+                if customer.custom_registration_scheme
+                else ""
+            ),
+            "registrationNumber": customer.custom_registration_number or "",
             "streetName": address.address_line1,
             "buildingNumber": address.address_line2,
             "citySubdivisionName": address.city,

--- a/zatca_integration/common_util.py
+++ b/zatca_integration/common_util.py
@@ -1,6 +1,5 @@
 import base64
 import hashlib
-import re
 import xml.etree.ElementTree as ET
 
 import frappe
@@ -36,97 +35,13 @@ def is_foreign_customer(customer):
     return bool(country) and country != "Saudi Arabia"
 
 
-def _sanitize_party_identification(value):
-    """BR-KSA-14: buyer/seller ID must be alphanumeric."""
-    return re.sub(r"[^A-Za-z0-9]", "", value or "")
-
-
-def _is_export_supply_invoice(invoice):
-    if not invoice.get("taxes_and_charges"):
-        return False
-    template = frappe.get_cached_doc("Sales Taxes and Charges Template", invoice.taxes_and_charges)
-    if template.get("custom_tax_type") != "Zero Rate":
-        return False
-    reason = template.get("custom_zero_rate_reason") or ""
-    export_codes = (
-        "VATEX-SA-32",
-        "VATEX-SA-33",
-        "VATEX-SA-34-1",
-        "VATEX-SA-34-2",
-        "VATEX-SA-34-3",
-        "VATEX-SA-34-4",
-        "VATEX-SA-34-5",
-    )
-    return any(code in reason for code in export_codes)
-
-
-def get_zatca_invoice_transaction_code(invoice):
-    """
-    KSA-2 invoice transaction code (NNPNESB).
-    Sets export flag (position 5) for non-KSA buyers or export zero-rated supplies.
-    """
-    customer = frappe.get_doc("Customer", invoice.customer)
-    if customer.customer_type == "Company":
-        code = list("0100000")
-    elif customer.customer_type == "Individual":
-        code = list("0200000")
-    else:
-        frappe.throw("Customer Type is not Supported")
-
-    if is_foreign_customer(customer) or _is_export_supply_invoice(invoice):
-        code[4] = "1"
-
-    return "".join(code)
-
-
-def get_buyer_party_identification(customer):
-    """
-    BT-46 PartyIdentification for the buyer when BT-48 (buyer VAT) is not in the XML.
-    BR-KSA-81 requires BT-46 on standard tax invoices (subtype 01) without BT-48.
-    Foreign buyers without a Saudi scheme should use OTH with a verifiable company ID.
-    """
-    if customer.customer_type != "Company":
-        return "", ""
-
-    if customer.custom_vat_number and not is_foreign_customer(customer):
-        return "", ""
-
-    scheme_code = ""
-    if customer.custom_registration_scheme:
-        scheme_code = get_registration_scheme_code(customer.custom_registration_scheme)
-
-    reg_number = _sanitize_party_identification(customer.custom_registration_number)
-    tax_id = _sanitize_party_identification(customer.get("tax_id"))
-
-    if scheme_code and reg_number:
-        return scheme_code, reg_number
-    if reg_number:
-        return "OTH", reg_number
-    if tax_id:
-        return "OTH", tax_id
-
-    return "", ""
-
-
 def validate_company_buyer_identification(customer):
     """
     ZATCA E-Invoicing Resolution Annex 5.3–5.4:
-    - Export (non-KSA buyer): buyer VAT and additional buyer ID are not mandatory in ERPNext.
+    - Export (non-KSA buyer): buyer VAT and additional buyer ID are not mandatory.
     - Saudi B2B: buyer VAT if applicable, or registration scheme + number if not VAT-registered.
-    BR-KSA-81: ZATCA still warns on clearance if BT-46 is missing when BT-48 is absent.
     """
-    if customer.customer_type != "Company":
-        return
-
-    if is_foreign_customer(customer):
-        _, party_id = get_buyer_party_identification(customer)
-        if not party_id:
-            frappe.msgprint(
-                "ZATCA warning BR-KSA-81: add the foreign company's registration "
-                "number on the Customer (scheme Other OD is used automatically), "
-                "or set Tax ID.",
-                indicator="orange",
-            )
+    if customer.customer_type != "Company" or is_foreign_customer(customer):
         return
 
     has_vat = bool(customer.custom_vat_number or customer.get("tax_id"))
@@ -150,7 +65,6 @@ def get_buyer_information(customer_name):
             frappe.throw("Customer must have a primary address")
 
         validate_company_buyer_identification(customer)
-        buyer_scheme, buyer_number = get_buyer_party_identification(customer)
 
         # ZATCA Address Validation
         # Address Line 1 is required
@@ -189,8 +103,12 @@ def get_buyer_information(customer_name):
         return {
             "organizationName": customer.customer_name,
             "vatNumber": customer.custom_vat_number,
-            "registrationScheme": buyer_scheme,
-            "registrationNumber": buyer_number,
+            "registrationScheme": (
+                get_registration_scheme_code(customer.custom_registration_scheme)
+                if customer.custom_registration_scheme
+                else ""
+            ),
+            "registrationNumber": customer.custom_registration_number or "",
             "streetName": address.address_line1,
             "buildingNumber": address.address_line2,
             "citySubdivisionName": address.city,

--- a/zatca_integration/common_util.py
+++ b/zatca_integration/common_util.py
@@ -1,5 +1,6 @@
 import base64
 import hashlib
+import re
 import xml.etree.ElementTree as ET
 
 import frappe
@@ -35,13 +36,97 @@ def is_foreign_customer(customer):
     return bool(country) and country != "Saudi Arabia"
 
 
+def _sanitize_party_identification(value):
+    """BR-KSA-14: buyer/seller ID must be alphanumeric."""
+    return re.sub(r"[^A-Za-z0-9]", "", value or "")
+
+
+def _is_export_supply_invoice(invoice):
+    if not invoice.get("taxes_and_charges"):
+        return False
+    template = frappe.get_cached_doc("Sales Taxes and Charges Template", invoice.taxes_and_charges)
+    if template.get("custom_tax_type") != "Zero Rate":
+        return False
+    reason = template.get("custom_zero_rate_reason") or ""
+    export_codes = (
+        "VATEX-SA-32",
+        "VATEX-SA-33",
+        "VATEX-SA-34-1",
+        "VATEX-SA-34-2",
+        "VATEX-SA-34-3",
+        "VATEX-SA-34-4",
+        "VATEX-SA-34-5",
+    )
+    return any(code in reason for code in export_codes)
+
+
+def get_zatca_invoice_transaction_code(invoice):
+    """
+    KSA-2 invoice transaction code (NNPNESB).
+    Sets export flag (position 5) for non-KSA buyers or export zero-rated supplies.
+    """
+    customer = frappe.get_doc("Customer", invoice.customer)
+    if customer.customer_type == "Company":
+        code = list("0100000")
+    elif customer.customer_type == "Individual":
+        code = list("0200000")
+    else:
+        frappe.throw("Customer Type is not Supported")
+
+    if is_foreign_customer(customer) or _is_export_supply_invoice(invoice):
+        code[4] = "1"
+
+    return "".join(code)
+
+
+def get_buyer_party_identification(customer):
+    """
+    BT-46 PartyIdentification for the buyer when BT-48 (buyer VAT) is not in the XML.
+    BR-KSA-81 requires BT-46 on standard tax invoices (subtype 01) without BT-48.
+    Foreign buyers without a Saudi scheme should use OTH with a verifiable company ID.
+    """
+    if customer.customer_type != "Company":
+        return "", ""
+
+    if customer.custom_vat_number and not is_foreign_customer(customer):
+        return "", ""
+
+    scheme_code = ""
+    if customer.custom_registration_scheme:
+        scheme_code = get_registration_scheme_code(customer.custom_registration_scheme)
+
+    reg_number = _sanitize_party_identification(customer.custom_registration_number)
+    tax_id = _sanitize_party_identification(customer.get("tax_id"))
+
+    if scheme_code and reg_number:
+        return scheme_code, reg_number
+    if reg_number:
+        return "OTH", reg_number
+    if tax_id:
+        return "OTH", tax_id
+
+    return "", ""
+
+
 def validate_company_buyer_identification(customer):
     """
     ZATCA E-Invoicing Resolution Annex 5.3–5.4:
-    - Export (non-KSA buyer): buyer VAT and additional buyer ID are not mandatory.
+    - Export (non-KSA buyer): buyer VAT and additional buyer ID are not mandatory in ERPNext.
     - Saudi B2B: buyer VAT if applicable, or registration scheme + number if not VAT-registered.
+    BR-KSA-81: ZATCA still warns on clearance if BT-46 is missing when BT-48 is absent.
     """
-    if customer.customer_type != "Company" or is_foreign_customer(customer):
+    if customer.customer_type != "Company":
+        return
+
+    if is_foreign_customer(customer):
+        _, party_id = get_buyer_party_identification(customer)
+        if not party_id:
+            frappe.msgprint(
+                "ZATCA warning BR-KSA-81: add the foreign company's registration "
+                "number on the Customer (scheme Other OD is used automatically), "
+                "or set Tax ID.",
+                indicator="orange",
+            )
         return
 
     has_vat = bool(customer.custom_vat_number or customer.get("tax_id"))
@@ -65,6 +150,7 @@ def get_buyer_information(customer_name):
             frappe.throw("Customer must have a primary address")
 
         validate_company_buyer_identification(customer)
+        buyer_scheme, buyer_number = get_buyer_party_identification(customer)
 
         # ZATCA Address Validation
         # Address Line 1 is required
@@ -103,12 +189,8 @@ def get_buyer_information(customer_name):
         return {
             "organizationName": customer.customer_name,
             "vatNumber": customer.custom_vat_number,
-            "registrationScheme": (
-                get_registration_scheme_code(customer.custom_registration_scheme)
-                if customer.custom_registration_scheme
-                else ""
-            ),
-            "registrationNumber": customer.custom_registration_number or "",
+            "registrationScheme": buyer_scheme,
+            "registrationNumber": buyer_number,
             "streetName": address.address_line1,
             "buildingNumber": address.address_line2,
             "citySubdivisionName": address.city,

--- a/zatca_integration/customization/sales_invoice/sales_invoice.py
+++ b/zatca_integration/customization/sales_invoice/sales_invoice.py
@@ -37,85 +37,17 @@ def set_base_retention_amount(doc, method):
     doc.custom_base_retention_amount = doc.conversion_rate * doc.custom_retention_amount
 
 
-def set_grand_total_with_retention(doc, method):
-    from erpnext.controllers.taxes_and_totals import calculate_taxes_and_totals
-
-    if not doc.doctype == "Sales Invoice":
+def adjust_outstanding_for_retention(doc, method):
+    """Reduce outstanding by retention while keeping grand_total full for ZATCA."""
+    if doc.doctype != "Sales Invoice":
         return
     if not doc.custom_retention_account or not doc.custom_retention_amount:
         return
 
-    # Monkey Patch calculate_totals method
-    calculate_taxes_and_totals.calculate_totals = custom_calculate_totals
-
-
-def custom_calculate_totals(self):
-    if self.doc.get("taxes"):
-        self.doc.grand_total = flt(self.doc.get("taxes")[-1].total) + flt(
-            self.doc.get("grand_total_diff")
-        )
-    else:
-        self.doc.grand_total = flt(self.doc.net_total)
-
-    if self.doc.get("taxes"):
-        self.doc.total_taxes_and_charges = flt(
-            self.doc.grand_total - self.doc.net_total - flt(self.doc.get("grand_total_diff")),
-            self.doc.precision("total_taxes_and_charges"),
-        )
-    else:
-        self.doc.total_taxes_and_charges = 0.0
-
-    # Make Grand Total Less Retention
-    if (
-        self.doc.doctype == "Sales Invoice"
-        and self.doc.custom_retention_account
-        and self.doc.custom_retention_amount
-    ):
-        self.doc.grand_total -= self.doc.custom_retention_amount
-
-    self._set_in_company_currency(self.doc, ["total_taxes_and_charges", "rounding_adjustment"])
-
-    if self.doc.doctype in [
-        "Quotation",
-        "Sales Order",
-        "Delivery Note",
-        "Sales Invoice",
-        "POS Invoice",
-    ]:
-        self.doc.base_grand_total = (
-            flt(
-                self.doc.grand_total * self.doc.conversion_rate,
-                self.doc.precision("base_grand_total"),
-            )
-            if self.doc.total_taxes_and_charges
-            else self.doc.base_net_total
-        )
-    else:
-        self.doc.taxes_and_charges_added = self.doc.taxes_and_charges_deducted = 0.0
-        for tax in self.doc.get("taxes"):
-            if tax.category in ["Valuation and Total", "Total"]:
-                if tax.add_deduct_tax == "Add":
-                    self.doc.taxes_and_charges_added += flt(tax.tax_amount_after_discount_amount)
-                else:
-                    self.doc.taxes_and_charges_deducted += flt(tax.tax_amount_after_discount_amount)
-
-        self.doc.round_floats_in(
-            self.doc, ["taxes_and_charges_added", "taxes_and_charges_deducted"]
-        )
-
-        self.doc.base_grand_total = (
-            flt(self.doc.grand_total * self.doc.conversion_rate)
-            if (self.doc.taxes_and_charges_added or self.doc.taxes_and_charges_deducted)
-            else self.doc.base_net_total
-        )
-
-        self._set_in_company_currency(
-            self.doc, ["taxes_and_charges_added", "taxes_and_charges_deducted"]
-        )
-
-    self.doc.round_floats_in(self.doc, ["grand_total", "base_grand_total"])
-
-    self.set_rounded_total()
+    doc.outstanding_amount = flt(
+        doc.outstanding_amount - flt(doc.custom_retention_amount),
+        doc.precision("outstanding_amount"),
+    )
 
 
 @frappe.whitelist()

--- a/zatca_integration/customization/sales_invoice/sales_invoice.py
+++ b/zatca_integration/customization/sales_invoice/sales_invoice.py
@@ -29,6 +29,19 @@ def update_delivery_date(delivery_note):
     return delivery_date
 
 
+def sync_retention_from_percentage(doc, method=None):
+    """Keep retention amount in sync when net total changes but percentage is set."""
+    if not doc.custom_retention_account or not flt(doc.custom_retention_percentage):
+        return
+    if not flt(doc.net_total):
+        return
+
+    doc.custom_retention_amount = flt(
+        flt(doc.net_total) * flt(doc.custom_retention_percentage) / 100,
+        doc.precision("custom_retention_amount"),
+    )
+
+
 def set_base_retention_amount(doc, method):
     if not doc.custom_retention_amount:
         return

--- a/zatca_integration/hooks.py
+++ b/zatca_integration/hooks.py
@@ -306,7 +306,7 @@ doc_events = {
             "zatca_integration.common_util.validate_pos_invoice",
             # "zatca_integration.common_util.update_delivery_date",
             "zatca_integration.customization.sales_invoice.sales_invoice.set_base_retention_amount",
-            "zatca_integration.customization.sales_invoice.sales_invoice.set_grand_total_with_retention",
+            "zatca_integration.customization.sales_invoice.sales_invoice.adjust_outstanding_for_retention",
         ],
         "before_submit": [
             "zatca_integration.common_util.validate_sales_invoice",

--- a/zatca_integration/hooks.py
+++ b/zatca_integration/hooks.py
@@ -340,8 +340,10 @@ doc_events = {
 # }
 # }
 
-# TODO: Uncomment when going to simulation or production
 scheduler_events = {
+    "hourly": [
+        "zatca_integration.saudi_arabia_electronic_invoicing.background_task.send_multiple_signed_compliance_invoices_to_zatca",  # noqa: E501
+    ],
     "weekly": [
         "zatca_integration.saudi_arabia_electronic_invoicing.background_task.notify_expiring_csids",  # noqa: E501
     ],

--- a/zatca_integration/hooks.py
+++ b/zatca_integration/hooks.py
@@ -305,6 +305,7 @@ doc_events = {
         "validate": [
             "zatca_integration.common_util.validate_pos_invoice",
             # "zatca_integration.common_util.update_delivery_date",
+            "zatca_integration.customization.sales_invoice.sales_invoice.sync_retention_from_percentage",
             "zatca_integration.customization.sales_invoice.sales_invoice.set_base_retention_amount",
             "zatca_integration.customization.sales_invoice.sales_invoice.adjust_outstanding_for_retention",
         ],

--- a/zatca_integration/overrides/sales_invoice.py
+++ b/zatca_integration/overrides/sales_invoice.py
@@ -15,7 +15,6 @@ class CustomSalesInvoice(SalesInvoice):
         gl_entries = []
 
         self.make_retention_gl_entry(gl_entries)
-
         self.make_customer_gl_entry(gl_entries)
 
         self.make_tax_gl_entries(gl_entries)
@@ -67,6 +66,59 @@ class CustomSalesInvoice(SalesInvoice):
                         "debit_in_account_currency": self.custom_base_retention_amount
                         if self.party_account_currency == self.company_currency
                         else self.custom_retention_amount,
+                        "against_voucher": against_voucher,
+                        "against_voucher_type": self.doctype,
+                        "cost_center": self.cost_center,
+                        "project": self.project,
+                    },
+                    self.party_account_currency,
+                    item=self,
+                )
+            )
+
+    def make_customer_gl_entry(self, gl_entries):
+        grand_total = (
+            self.rounded_total
+            if (self.rounding_adjustment and self.rounded_total)
+            else self.grand_total
+        )
+        base_grand_total = flt(
+            self.base_rounded_total
+            if (self.base_rounding_adjustment and self.base_rounded_total)
+            else self.base_grand_total,
+            self.precision("base_grand_total"),
+        )
+
+        if self.custom_retention_account and self.custom_retention_amount:
+            retention = flt(self.custom_retention_amount)
+            base_retention = flt(
+                self.custom_base_retention_amount
+                if self.custom_base_retention_amount
+                else retention * flt(self.conversion_rate)
+            )
+            grand_total = flt(grand_total - retention, self.precision("grand_total"))
+            base_grand_total = flt(
+                base_grand_total - base_retention, self.precision("base_grand_total")
+            )
+
+        if grand_total and not self.is_internal_transfer():
+            against_voucher = self.name
+            if self.is_return and self.return_against and not self.update_outstanding_for_self:
+                against_voucher = self.return_against
+
+            gl_entries.append(
+                self.get_gl_dict(
+                    {
+                        "account": self.debit_to,
+                        "party_type": "Customer",
+                        "party": self.customer,
+                        "due_date": self.due_date,
+                        "against": self.against_income_account,
+                        "debit": base_grand_total,
+                        "debit_in_account_currency": base_grand_total
+                        if self.party_account_currency == self.company_currency
+                        else grand_total,
+                        "debit_in_transaction_currency": grand_total,
                         "against_voucher": against_voucher,
                         "against_voucher_type": self.doctype,
                         "cost_center": self.cost_center,

--- a/zatca_integration/public/js/sales_invoice.js
+++ b/zatca_integration/public/js/sales_invoice.js
@@ -63,16 +63,7 @@ frappe.ui.form.on('Sales Invoice', {
 },
 
     validate: frm => {
-        if (frm.is_new() && frm.doc.custom_retention_account && frm.doc.custom_retention_amount) {
-            frm.set_value(
-                'grand_total',
-                (frm.doc.net_total + frm.doc.total_taxes_and_charges - frm.doc.custom_retention_amount)            );
-            frm.refresh_field('grand_total');
-            console.log('Retention amount deducted from grand total');
-        }
         create_missing_cn_reference(frm);
-
-
     },
 
 
@@ -106,12 +97,9 @@ frappe.ui.form.on('Sales Invoice', {
     custom_retention_amount: function(frm) {
         if (!frm.doc.custom_retention_account) {
             frappe.throw(__("Please select a Retention Account"));
-        }else {
+        } else {
             let percentage = (frm.doc.custom_retention_amount / frm.doc.net_total) * 100;
             frm.set_value('custom_retention_percentage', percentage);
-            // Update the grand total
-            frm.set_value('grand_total', (frm.doc.net_total + frm.doc.total_taxes_and_charges - frm.doc.custom_retention_amount));
-            frm.refresh_field('grand_total');
         }
     },
     custom_generate_pdf3a_through: function(frm) {
@@ -125,10 +113,6 @@ frappe.ui.form.on('Sales Invoice', {
 
         frm.set_value('custom_retention_amount', retention);
         frm.refresh_field('custom_retention_amount');
-
-        // Update the grand total
-        frm.set_value('grand_total', (frm.doc.net_total + frm.doc.total_taxes_and_charges - retention));
-        frm.refresh_field('grand_total');
     },
     set_custom_payment_method: frm => {
         //check the frm is submitted or not

--- a/zatca_integration/public/js/sales_invoice.js
+++ b/zatca_integration/public/js/sales_invoice.js
@@ -90,16 +90,33 @@ frappe.ui.form.on('Sales Invoice', {
         if (!frm.doc.custom_retention_account) {
             frappe.throw(__("Please select a Retention Account"));
         }
-        if ( frm.doc.custom_retention_account && frm.doc.custom_retention_percentage) {
+        if (frm.doc.custom_retention_account && frm.doc.custom_retention_percentage) {
             frm.trigger('set_retention_amount');
         }
     },
     custom_retention_amount: function(frm) {
+        if (frm._updating_retention) {
+            return;
+        }
         if (!frm.doc.custom_retention_account) {
             frappe.throw(__("Please select a Retention Account"));
-        } else {
-            let percentage = (frm.doc.custom_retention_amount / frm.doc.net_total) * 100;
-            frm.set_value('custom_retention_percentage', percentage);
+        }
+        if (!frm.doc.net_total) {
+            return;
+        }
+        let percentage = (frm.doc.custom_retention_amount / frm.doc.net_total) * 100;
+        frm.set_value('custom_retention_percentage', percentage);
+    },
+    calculate: function(frm) {
+        // Recalculate retention when items/taxes change net total (percentage-based retention).
+        frm.trigger('sync_retention_amount');
+    },
+    sync_retention_amount: function(frm) {
+        if (
+            frm.doc.custom_retention_account &&
+            frm.doc.custom_retention_percentage
+        ) {
+            frm.trigger('set_retention_amount');
         }
     },
     custom_generate_pdf3a_through: function(frm) {
@@ -107,12 +124,28 @@ frappe.ui.form.on('Sales Invoice', {
         frm.refresh();
     },
     set_retention_amount: frm => {
-        let retention = frm.doc.custom_retention_percentage
-            ? (frm.doc.net_total * frm.doc.custom_retention_percentage / 100)
-            : frm.doc.custom_retention_amount;
+        if (!frm.doc.custom_retention_account) {
+            return;
+        }
 
+        let retention;
+        if (frm.doc.custom_retention_percentage) {
+            retention = (flt(frm.doc.net_total) * flt(frm.doc.custom_retention_percentage)) / 100;
+        } else if (frm.doc.custom_retention_amount) {
+            retention = frm.doc.custom_retention_amount;
+        } else {
+            return;
+        }
+
+        frm._updating_retention = true;
         frm.set_value('custom_retention_amount', retention);
-        frm.refresh_field('custom_retention_amount');
+        if (frm.doc.conversion_rate) {
+            frm.set_value(
+                'custom_base_retention_amount',
+                flt(retention) * flt(frm.doc.conversion_rate)
+            );
+        }
+        frm._updating_retention = false;
     },
     set_custom_payment_method: frm => {
         //check the frm is submitted or not

--- a/zatca_integration/saudi_arabia_electronic_invoicing/signing_engine/generate_final_xml.py
+++ b/zatca_integration/saudi_arabia_electronic_invoicing/signing_engine/generate_final_xml.py
@@ -228,6 +228,99 @@ def add_line_item_discount(cac_price, single_item, sales_invoice_doc):
         return None
 
 
+def _quantize_money(value):
+    return Decimal(str(value)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def _get_item_unit_net_rate(item, included, tax_rate):
+    rate_to_use = flt(item.rate)
+    if included:
+        rate_to_use = rate_to_use / (1 + flt(tax_rate) / 100)
+    return abs(rate_to_use)
+
+
+def _compute_zatca_line_amounts(qty, unit_net_rate):
+    """BT-131 = BT-129 * (BT-146 / BT-149) with BT-149 fixed to 1."""
+    quantity = _quantize_money(abs(qty))
+    unit_price = _quantize_money(unit_net_rate)
+    line_extension = (quantity * unit_price).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    return quantity, unit_price, line_extension
+
+
+def _get_expected_line_extension_total(sales_invoice_doc, included):
+    if sales_invoice_doc.currency == "SAR":
+        amount = sales_invoice_doc.base_net_total if not included else sales_invoice_doc.net_total
+    else:
+        amount = sales_invoice_doc.net_total if not included else sales_invoice_doc.total
+    return _quantize_money(abs(amount))
+
+
+def _line_item_tax_amount(line_extension, tax_rate, included):
+    line_extension = Decimal(str(line_extension))
+    tax_rate = Decimal(str(tax_rate))
+    if included:
+        tax_amount = line_extension * tax_rate / (Decimal("100") + tax_rate)
+    else:
+        tax_amount = line_extension * tax_rate / Decimal("100")
+    return abs(tax_amount.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
+
+
+def _reconcile_line_extension_entries(line_entries, expected_total):
+    """
+    Keep BR-KSA-EN16931-11 per line (qty * unit price) and match ERPNext net total
+    by absorbing rounding difference on a qty=1 line when possible.
+    """
+    if not line_entries:
+        return
+
+    current_total = sum(entry["line_extension"] for entry in line_entries)
+    difference = expected_total - current_total
+    if difference == 0:
+        return
+
+    adjust_idx = next(
+        (i for i in range(len(line_entries) - 1, -1, -1) if line_entries[i]["quantity"] == 1),
+        len(line_entries) - 1,
+    )
+    entry = line_entries[adjust_idx]
+    target_line_extension = (entry["line_extension"] + difference).quantize(
+        Decimal("0.01"), rounding=ROUND_HALF_UP
+    )
+
+    if entry["quantity"] == 1:
+        entry["unit_price"] = target_line_extension
+        entry["line_extension"] = target_line_extension
+        return
+
+    entry["unit_price"] = (target_line_extension / entry["quantity"]).quantize(
+        Decimal("0.01"), rounding=ROUND_HALF_UP
+    )
+    entry["line_extension"] = (entry["quantity"] * entry["unit_price"]).quantize(
+        Decimal("0.01"), rounding=ROUND_HALF_UP
+    )
+
+    remaining = expected_total - sum(e["line_extension"] for e in line_entries)
+    if remaining == 0 or entry["quantity"] != 1:
+        return
+
+    entry["unit_price"] = (entry["line_extension"] + remaining).quantize(
+        Decimal("0.01"), rounding=ROUND_HALF_UP
+    )
+    entry["line_extension"] = entry["unit_price"]
+
+
+def _apply_line_entry_to_xml(entry, currency, tax_rate, included):
+    entry["line_ext_elem"].text = f"{entry['line_extension']:.2f}"
+    entry["price_elem"].text = f"{entry['unit_price']:.2f}"
+
+    tax_amount = _line_item_tax_amount(entry["line_extension"], tax_rate, included)
+    entry["tax_amount_elem"].text = f"{tax_amount:.2f}"
+    line_total = (entry["line_extension"] + tax_amount).quantize(
+        Decimal("0.01"), rounding=ROUND_HALF_UP
+    )
+    entry["rounding_elem"].text = f"{line_total:.2f}"
+
+
 def item_data(invoice, sales_invoice_doc):
     """
     Create UBL-compliant item-level XML lines without using Item Tax Template.
@@ -235,59 +328,36 @@ def item_data(invoice, sales_invoice_doc):
     """
     try:
         tax_details = get_zatca_tax_category_details(sales_invoice_doc)
-        _rate = Decimal(str(tax_details["rate"]))
         code = tax_details["code"]
+        tax_rate = Decimal(str(sales_invoice_doc.taxes[0].rate))
+        included = sales_invoice_doc.taxes[0].included_in_print_rate
+        line_entries = []
 
         for item in sales_invoice_doc.items:
-            tax_rate = Decimal(str(sales_invoice_doc.taxes[0].rate))
-            included = sales_invoice_doc.taxes[0].included_in_print_rate
+            unit_net_rate = _get_item_unit_net_rate(item, included, tax_rate)
+            quantity, unit_price, line_extension = _compute_zatca_line_amounts(item.qty, unit_net_rate)
 
             cac_invoiceline = ET.SubElement(invoice, "cac:InvoiceLine")
 
-            # ID and Quantity
             ET.SubElement(cac_invoiceline, "cbc:ID").text = str(item.idx)
             invoiced_quantity = ET.SubElement(cac_invoiceline, "cbc:InvoicedQuantity")
             invoiced_quantity.set("unitCode", str(item.uom))
             invoiced_quantity.text = str(abs(item.qty))
 
-            # Line Extension Amount
             line_ext_amt = ET.SubElement(cac_invoiceline, "cbc:LineExtensionAmount")
             line_ext_amt.set("currencyID", sales_invoice_doc.currency)
-            if included:
-                base = item.base_amount if sales_invoice_doc.currency == "SAR" else item.amount
-                line_ext_amt.text = str(round(abs(base / (1 + float(tax_rate) / 100)), 2))
-            else:
-                base = item.base_amount if sales_invoice_doc.currency == "SAR" else item.amount
-                line_ext_amt.text = str(abs(base))
 
-            # Tax Total per Item
             cac_taxtotal = ET.SubElement(cac_invoiceline, "cac:TaxTotal")
             tax_amount_elem = ET.SubElement(cac_taxtotal, "cbc:TaxAmount")
             tax_amount_elem.set("currencyID", sales_invoice_doc.currency)
 
-            item_base_amount = Decimal(str(item.base_amount))
-            item_amount = Decimal(str(item.amount))
-
-            if included:
-                tax_amount = item_base_amount * tax_rate / (Decimal("100") + tax_rate)
-            else:
-                tax_amount = item_amount * tax_rate / Decimal("100")
-
-            tax_amount_elem.text = str(
-                abs(Decimal(tax_amount).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
-            )
-
-            # Optional Rounding Amount
             rounding = ET.SubElement(cac_taxtotal, "cbc:RoundingAmount")
             rounding.set("currencyID", sales_invoice_doc.currency)
-            rounding.text = str(round(float(line_ext_amt.text) + float(tax_amount_elem.text), 2))
 
-            # Item Info
             cac_item = ET.SubElement(cac_invoiceline, "cac:Item")
             name = ET.SubElement(cac_item, "cbc:Name")
             name.text = f"{item.item_code}:{item.item_name}"
 
-            # Classified Tax Category
             classified = ET.SubElement(cac_item, "cac:ClassifiedTaxCategory")
             ET.SubElement(classified, "cbc:ID").text = code
             ET.SubElement(classified, "cbc:Percent").text = f"{float(tax_rate):.2f}"
@@ -301,65 +371,38 @@ def item_data(invoice, sales_invoice_doc):
             tax_scheme = ET.SubElement(classified, "cac:TaxScheme")
             ET.SubElement(tax_scheme, "cbc:ID").text = "VAT"
 
-            # Price
             cac_price = ET.SubElement(cac_invoiceline, "cac:Price")
             price_amt = ET.SubElement(cac_price, "cbc:PriceAmount")
             price_amt.set("currencyID", sales_invoice_doc.currency)
 
-            # Handle price according to nominal flag and included_in_print_rate
-            rate_to_use = item.rate
-            if included:
-                rate_to_use = item.rate / (1 + float(tax_rate) / 100)
-
-            price_amt.text = str(round(abs(rate_to_use), 2))
-
             base_quantity = ET.SubElement(cac_price, "cbc:BaseQuantity", unitCode=str(item.uom))
             base_quantity.text = "1"
-        # I just added this
-        # invoice = adjust_line_extension_totals(invoice, sales_invoice_doc)
+
+            line_entries.append(
+                {
+                    "quantity": quantity,
+                    "unit_price": unit_price,
+                    "line_extension": line_extension,
+                    "line_ext_elem": line_ext_amt,
+                    "price_elem": price_amt,
+                    "tax_amount_elem": tax_amount_elem,
+                    "rounding_elem": rounding,
+                }
+            )
+
+        expected_total = _get_expected_line_extension_total(sales_invoice_doc, included)
+        _reconcile_line_extension_entries(line_entries, expected_total)
+
+        for entry in line_entries:
+            _apply_line_entry_to_xml(
+                entry, sales_invoice_doc.currency, tax_rate, included
+            )
+
         return invoice
 
     except Exception as e:
         frappe.throw(_("Error occurred in item data processing: {0}").format(str(e)))
         return None
-
-
-def adjust_line_extension_totals(invoice, sales_invoice_doc):
-    """
-    Adjust last item's LineExtensionAmount so the total matches ERPNext calculated total.
-    """
-    included = sales_invoice_doc.taxes[0].included_in_print_rate
-
-    # The expected total based on ERPNext doc
-    expected_total = round(
-        abs(sales_invoice_doc.total if included == 0 else sales_invoice_doc.base_net_total), 2
-    )
-
-    # Find all line extension amounts from XML using iter()
-    line_ext_elems = []
-    for elem in invoice.iter():
-        if elem.tag == "cbc:LineExtensionAmount":
-            line_ext_elems.append(elem)
-
-    if not line_ext_elems:
-        frappe.throw("No LineExtensionAmount elements found")
-        return invoice
-
-    # Calculate current total
-    current_total = round(sum(float(el.text) for el in line_ext_elems), 2)
-
-    # If totals differ, adjust the last item's amount
-    difference = round(expected_total - current_total, 2)
-
-    # Remove this debug line once working:
-    frappe.throw(f"Expected: {expected_total}, Current: {current_total}, Difference: {difference}")
-
-    if difference != 0:
-        last_elem = line_ext_elems[-1]
-        last_value = round(float(last_elem.text) + difference, 2)
-        last_elem.text = str(last_value)
-
-    return invoice
 
 
 # --- Helper Function ---

--- a/zatca_integration/saudi_arabia_electronic_invoicing/signing_engine/generate_invoice_xml.py
+++ b/zatca_integration/saudi_arabia_electronic_invoicing/signing_engine/generate_invoice_xml.py
@@ -8,7 +8,11 @@ import frappe
 from frappe import _
 from frappe.utils.data import get_time
 
-from zatca_integration.common_util import generate_invoice_hash, get_registration_scheme_code
+from zatca_integration.common_util import (
+    generate_invoice_hash,
+    get_registration_scheme_code,
+    validate_company_buyer_identification,
+)
 from zatca_integration.saudi_arabia_electronic_invoicing.utils import (
     get_address,
     get_previous_invoice_counter,
@@ -625,6 +629,7 @@ def customer_data(invoice, sales_invoice_doc):
     """
     Add customer data (address, registration, tax info) to the XML invoice.
     Skips <PartyIdentification> if registration scheme or number is missing.
+    Non-KSA buyers may omit VAT and registration (ZATCA export rules, Annex 5.3–5.4).
     """
     try:
         customer_doc = frappe.get_doc("Customer", sales_invoice_doc.customer)
@@ -731,16 +736,7 @@ def customer_data(invoice, sales_invoice_doc):
 
 
 def vat_registration_validator(doc):
-    if doc.customer_type == "Company":
-        has_vat = bool(doc.get("custom_vat_number") or doc.get("tax_id"))
-        has_registration_number = bool(doc.get("custom_registration_number"))
-
-        if not (has_vat or has_registration_number):
-            frappe.throw(
-                _(
-                    "Customers of type 'Company' must have at least one of: VAT Number or Registration Number."
-                )
-            )
+    validate_company_buyer_identification(doc)
 
 
 def delivery_and_payment_means(invoice, sales_invoice_doc, is_return):

--- a/zatca_integration/saudi_arabia_electronic_invoicing/signing_engine/generate_invoice_xml.py
+++ b/zatca_integration/saudi_arabia_electronic_invoicing/signing_engine/generate_invoice_xml.py
@@ -10,7 +10,9 @@ from frappe.utils.data import get_time
 
 from zatca_integration.common_util import (
     generate_invoice_hash,
+    get_buyer_party_identification,
     get_registration_scheme_code,
+    get_zatca_invoice_transaction_code,
     validate_company_buyer_identification,
 )
 from zatca_integration.saudi_arabia_electronic_invoicing.utils import (
@@ -312,17 +314,7 @@ def invoice_typecode_simplified(invoice, sales_invoice_doc):
 
 
 def get_invoice_type_code(invoice):
-    invoice_type = "0"
-    customer = invoice.customer
-    customer = frappe.get_doc("Customer", invoice.customer)
-    customer_type = customer.customer_type
-    if customer_type == "Company":
-        invoice_type = "0100000"
-    elif customer_type == "Individual":
-        invoice_type = "0200000"
-    else:
-        frappe.throw("Customer Type is not Supported")
-    return invoice_type
+    return get_zatca_invoice_transaction_code(invoice)
 
 
 def invoice_typecode_standard(invoice, sales_invoice_doc):
@@ -629,18 +621,16 @@ def customer_data(invoice, sales_invoice_doc):
     """
     Add customer data (address, registration, tax info) to the XML invoice.
     Skips <PartyIdentification> if registration scheme or number is missing.
-    Non-KSA buyers may omit VAT and registration (ZATCA export rules, Annex 5.3–5.4).
+    BT-46 (buyer ID) is required by BR-KSA-81 when BT-48 (buyer VAT) is absent on standard invoices.
     """
     try:
         customer_doc = frappe.get_doc("Customer", sales_invoice_doc.customer)
         vat_registration_validator(customer_doc)
-        scheme_code = get_registration_scheme_code(customer_doc.custom_registration_scheme) or ""
-        customer_registration_number = customer_doc.custom_registration_number or ""
+        scheme_code, customer_registration_number = get_buyer_party_identification(customer_doc)
 
         cac_accountingcustomerparty = ET.SubElement(invoice, "cac:AccountingCustomerParty")
         cac_party_2 = ET.SubElement(cac_accountingcustomerparty, "cac:Party")
 
-        # Only add PartyIdentification if both scheme_code and registration_number are present
         if scheme_code and customer_registration_number:
             cac_partyidentification_1 = ET.SubElement(cac_party_2, "cac:PartyIdentification")
             cbc_id_4 = ET.SubElement(cac_partyidentification_1, CBC_ID)

--- a/zatca_integration/saudi_arabia_electronic_invoicing/signing_engine/generate_invoice_xml.py
+++ b/zatca_integration/saudi_arabia_electronic_invoicing/signing_engine/generate_invoice_xml.py
@@ -10,9 +10,7 @@ from frappe.utils.data import get_time
 
 from zatca_integration.common_util import (
     generate_invoice_hash,
-    get_buyer_party_identification,
     get_registration_scheme_code,
-    get_zatca_invoice_transaction_code,
     validate_company_buyer_identification,
 )
 from zatca_integration.saudi_arabia_electronic_invoicing.utils import (
@@ -314,7 +312,13 @@ def invoice_typecode_simplified(invoice, sales_invoice_doc):
 
 
 def get_invoice_type_code(invoice):
-    return get_zatca_invoice_transaction_code(invoice)
+    customer = frappe.get_doc("Customer", invoice.customer)
+    customer_type = customer.customer_type
+    if customer_type == "Company":
+        return "0100000"
+    if customer_type == "Individual":
+        return "0200000"
+    frappe.throw("Customer Type is not Supported")
 
 
 def invoice_typecode_standard(invoice, sales_invoice_doc):
@@ -621,16 +625,18 @@ def customer_data(invoice, sales_invoice_doc):
     """
     Add customer data (address, registration, tax info) to the XML invoice.
     Skips <PartyIdentification> if registration scheme or number is missing.
-    BT-46 (buyer ID) is required by BR-KSA-81 when BT-48 (buyer VAT) is absent on standard invoices.
+    Non-KSA buyers may omit VAT and registration (ZATCA export rules, Annex 5.3–5.4).
     """
     try:
         customer_doc = frappe.get_doc("Customer", sales_invoice_doc.customer)
         vat_registration_validator(customer_doc)
-        scheme_code, customer_registration_number = get_buyer_party_identification(customer_doc)
+        scheme_code = get_registration_scheme_code(customer_doc.custom_registration_scheme) or ""
+        customer_registration_number = customer_doc.custom_registration_number or ""
 
         cac_accountingcustomerparty = ET.SubElement(invoice, "cac:AccountingCustomerParty")
         cac_party_2 = ET.SubElement(cac_accountingcustomerparty, "cac:Party")
 
+        # Only add PartyIdentification if both scheme_code and registration_number are present
         if scheme_code and customer_registration_number:
             cac_partyidentification_1 = ET.SubElement(cac_party_2, "cac:PartyIdentification")
             cbc_id_4 = ET.SubElement(cac_partyidentification_1, CBC_ID)


### PR DESCRIPTION
1. Retention GL was always added on submit  
`make_retention_gl_entry`  ran whenever retention fields were filled in.

2. Customer GL was never reduced  
`make_customer_gl_entry`  always debited the full  `grand_total`, because nothing reliably lowered it for posting.

3. Broken server logic  
The old  `set_grand_total_with_retention`  hook only  patched  tax calculation  after  ERPNext had already recalculated totals, and it  never ran that calculation again. So on every save,  `grand_total`  was reset to the full tax total and retention was never subtracted server-side.


## What we changed (in one sentence)

We stopped trying to shrink  `grand_total`  (so  ZATCA still sees the full amount), and instead:

-   Customer GL  debits  `grand_total − retention`
-   Outstanding  is  `grand_total − retention`  for payments
-   Retention GL  still debits the held amount

Now both sides of the journal add up to 22,698.20 while ZATCA keeps reporting the full invoice total.